### PR TITLE
check crc, line numbers, throw exception after too many resets

### DIFF
--- a/pylepton/__init__.py
+++ b/pylepton/__init__.py
@@ -1,4 +1,3 @@
 __all__ = ["Lepton"]
 
-# relative imports in Python3 must be explicit
-from .Lepton import Lepton
+from Lepton import Lepton

--- a/pylepton/ioctl_numbers.py
+++ b/pylepton/ioctl_numbers.py
@@ -39,8 +39,7 @@ _IOC_READ = 2
 
 
 def _IOC(dir, type, nr, size):
-    # in Python3, unicode -> str; str -> bytes
-    if isinstance(size, bytes) or isinstance(size, str):
+    if isinstance(size, str) or isinstance(size, unicode):
         size = struct.calcsize(size)
     return dir  << _IOC_DIRSHIFT  | \
            type << _IOC_TYPESHIFT | \


### PR DESCRIPTION
changed Lepton.py to:
- check all line numbers ( not just 20 ) after whole frame is read
- check crc after whole frame is read
- allow configurable number of retries so pylepton does not wait forever for a frame

sorry, this is still for the old python2 code. I'm new to GIT and github  and just wanted to get this code out there since it fixes some glaring omissions in the original.